### PR TITLE
Allow fetching the last used signing key

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -81,6 +81,13 @@ class OneLogin_Saml2_Auth
     private $_lastAssertionNotOnOrAfter;
 
     /**
+     * The signing certificate of the last assertion processed
+     *
+     * @var string
+     */
+    private $_lastSigningCertificate;
+
+    /**
      * If any error.
      *
      * @var array
@@ -183,6 +190,7 @@ class OneLogin_Saml2_Auth
                 $this->_lastMessageId = $response->getId();
                 $this->_lastAssertionId = $response->getAssertionId();
                 $this->_lastAssertionNotOnOrAfter = $response->getAssertionNotOnOrAfter();
+                $this->_lastSigningCertificate = $response->getSigningCertificate();
             } else {
                 $this->_errors[] = 'invalid_response';
                 $this->_errorReason = $response->getError();
@@ -638,6 +646,14 @@ class OneLogin_Saml2_Auth
     public function getLastAssertionNotOnOrAfter()
     {
         return $this->_lastAssertionNotOnOrAfter;
+    }
+
+    /**
+     * @return The certificate used to sign the response
+     */
+    public function getLastSigningCertificate()
+    {
+        return $this->_lastSigningCertificate;
     }
 
     /**

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -52,6 +52,11 @@ class OneLogin_Saml2_Response
     private $_validSCDNotOnOrAfter;
 
     /**
+     * The signing key used to validate the response
+     */
+    private $_signkey;
+
+    /**
      * Constructs the SAML Response object.
      *
      * @param OneLogin_Saml2_Settings $settings Settings.
@@ -100,6 +105,7 @@ class OneLogin_Saml2_Response
     public function isValid($requestId = null)
     {
         $this->_error = null;
+        $this->_signkey = null;
         try {
             // Check SAML version
             if ($this->document->documentElement->getAttribute('Version') != '2.0') {
@@ -396,6 +402,7 @@ class OneLogin_Saml2_Response
                         OneLogin_Saml2_ValidationError::INVALID_SIGNATURE
                     );
                 }
+                $this->_signkey = OneLogin_Saml2_Utils::getLastSigningKey();
             }
             return true;
         } catch (Exception $e) {
@@ -1099,5 +1106,10 @@ class OneLogin_Saml2_Response
         } else {
             return $this->document;
         }
+    }
+
+    public function getSigningCertificate()
+    {
+        return $this->_signkey;
     }
 }

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -941,13 +941,13 @@ class OneLogin_Saml2_Settings
     {
         if (isset($this->_idp['x509certMulti'])) {
             if (isset($this->_idp['x509certMulti']['signing'])) {
-                for ($i=0; $i < count($this->_idp['x509certMulti']['signing']); $i++) {
-                    $this->_idp['x509certMulti']['signing'][$i] = OneLogin_Saml2_Utils::formatCert($this->_idp['x509certMulti']['signing'][$i]);
+                foreach($this->_idp['x509certMulti']['signing'] as $i => $cert) {
+                    $this->_idp['x509certMulti']['signing'][$i] = OneLogin_Saml2_Utils::formatCert($cert);
                 }
             }
             if (isset($this->_idp['x509certMulti']['encryption'])) {
-                for ($i=0; $i < count($this->_idp['x509certMulti']['encryption']); $i++) {
-                    $this->_idp['x509certMulti']['encryption'][$i] = OneLogin_Saml2_Utils::formatCert($this->_idp['x509certMulti']['encryption'][$i]);
+                foreach($this->_idp['x509certMulti']['encryption'] as $i => $cert) {
+                    $this->_idp['x509certMulti']['encryption'][$i] = OneLogin_Saml2_Utils::formatCert($cert);
                 }
             }
         }

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -37,6 +37,10 @@ class OneLogin_Saml2_Utils
      */
     private static $_baseurlpath;
 
+    /**
+     * @var string
+     */
+    private static $_lastsignkey;
 
     /**
      * Translates any string. Accepts args
@@ -1324,10 +1328,12 @@ class OneLogin_Saml2_Utils
         }
 
         $valid = false;
+        self::$_lastsignkey = null;
         foreach ($multiCerts as $cert) {
             if (!empty($cert)) {
                 $objKey->loadKey($cert, false, true);
                 if ($objXMLSecDSig->verify($objKey) === 1) {
+                    self::$_lastsignkey = $cert;
                     $valid = true;
                     break;
                 }
@@ -1338,6 +1344,7 @@ class OneLogin_Saml2_Utils
                     if (OneLogin_Saml2_Utils::formatFingerPrint($fingerprint) == $domCertFingerprint) {
                         $objKey->loadKey($domCert, false, true);
                         if ($objXMLSecDSig->verify($objKey) === 1) {
+                            self::$_lastsignkey = $cert;
                             $valid = true;
                             break;
                         }
@@ -1390,6 +1397,7 @@ class OneLogin_Saml2_Utils
         }
 
         $signatureValid = false;
+        self::$_lastsignkey = null;
         foreach ($multiCerts as $cert) {
             $objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type' => 'public'));
             $objKey->loadKey($cert, false, true);
@@ -1409,10 +1417,16 @@ class OneLogin_Saml2_Utils
             }
 
             if ($objKey->verifySignature($signedQuery, base64_decode($_GET['Signature'])) === 1) {
+                self::$_lastsignkey = $cert;
                 $signatureValid = true;
                 break;
             }
         }
         return $signatureValid;
+    }
+
+    public static function getLastSigningKey()
+    {
+        return self::$_lastsignkey;
     }
 }


### PR DESCRIPTION
To supplement the x509certMulti feature added in issue #140, this propagates the signing certificate back to the auth caller. The caller may want to know when a different certificate is used.