### PR TITLE
Add signature to AuthnRequest when flags are true (not just in parameters)

### DIFF
--- a/src/Saml2/AuthnRequest.php
+++ b/src/Saml2/AuthnRequest.php
@@ -165,6 +165,16 @@ REQUESTEDAUTHN;
 </samlp:AuthnRequest>
 AUTHNREQUEST;
 
+        if (isset($security['authnRequestsSigned']) && $security['authnRequestsSigned']) {
+            // add signature to the authnRequest to prevent rejection
+            try {
+                $options =  array('id_name' => 'ID', 'overwrite' => false);
+                $request = Utils::addSign($request, $spData['privateKey'], $spData['x509cert'], $security['signatureAlgorithm'], $security['digestAlgorithm'], $options);
+            } catch (\Exception $exception) {
+                throw new Error('Could not put signature in AuthnRequest Body, ' . $exception->getMessage());
+            }
+        }
+
         $this->_id = $id;
         $this->_authnRequest = $request;
     }

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -1334,7 +1334,7 @@ class Utils
      *
      * @throws Exception
      */
-    public static function addSign($xml, $key, $cert, $signAlgorithm = XMLSecurityKey::RSA_SHA1, $digestAlgorithm = XMLSecurityDSig::SHA1, $options = null)
+    public static function addSign($xml, $key, $cert, $signAlgorithm = XMLSecurityKey::RSA_SHA256, $digestAlgorithm = XMLSecurityDSig::SHA256, $options = null)
     {
         if (is_null($options)) {
             $options =  array('id_name' => 'ID');

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -1328,13 +1328,17 @@ class Utils
      * @param string             $cert            The public
      * @param string             $signAlgorithm   Signature algorithm method
      * @param string             $digestAlgorithm Digest algorithm method
+     * @param array|null         $options       options for xmlseclibs
      *
      * @return string
      *
      * @throws Exception
      */
-    public static function addSign($xml, $key, $cert, $signAlgorithm = XMLSecurityKey::RSA_SHA256, $digestAlgorithm = XMLSecurityDSig::SHA256)
+    public static function addSign($xml, $key, $cert, $signAlgorithm = XMLSecurityKey::RSA_SHA1, $digestAlgorithm = XMLSecurityDSig::SHA1, $options = null)
     {
+        if (is_null($options)) {
+            $options =  array('id_name' => 'ID');
+        }
         if ($xml instanceof DOMDocument) {
             $dom = $xml;
         } else {
@@ -1360,7 +1364,7 @@ class Utils
             array($rootNode),
             $digestAlgorithm,
             array('http://www.w3.org/2000/09/xmldsig#enveloped-signature', XMLSecurityDSig::EXC_C14N),
-            array('id_name' => 'ID')
+            $options
         );
 
         $objXMLSecDSig->sign($objKey);


### PR DESCRIPTION
I couldn't see anywhere in the library that added signatures to the login AuthnRequest when signing was true (only the parameters).

This pull request is to do that so that an unsigned AuthnRequest body is not rejected despite true flags being set.