### PR TITLE
Fix: buildWithBaseURLPath corrupts the current route if it contains slashes, causing assertion validation to fail #249

### DIFF
--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -704,10 +704,11 @@ class OneLogin_Saml2_Utils
         if (!empty($baseURLPath) && !empty($info)) {
             $path = explode('/', $info);
             if (count($path) > 1) {
-                $info = implode(array_filter($path),'/');
+                $info = implode(array_filter($path), '/');
             }
             $result .= $baseURLPath . $info;
         }
+
         return $result;
     }
 

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -701,15 +701,12 @@ class OneLogin_Saml2_Utils
     {
         $result = '';
         $baseURLPath = self::getBaseURLPath();
-        if (!empty($baseURLPath)) {
-            $result = $baseURLPath;
-            if (!empty($info)) {
-                $path = explode('/', $info);
-                $extractedInfo = array_pop($path);
-                if (!empty($extractedInfo)) {
-                    $result .= $extractedInfo;
-                }
+        if (!empty($baseURLPath) && !empty($info)) {
+            $path = explode('/', $info);
+            if (count($path) > 1) {
+                $info = implode(array_filter($path),'/');
             }
+            $result .= $baseURLPath . $info;
         }
         return $result;
     }


### PR DESCRIPTION
Fix buildWithBaseURLPath corrupts the current route if it contains slashes, causing assertion validation to fail