### PR TITLE
enable empty nameId when wantNameId is false

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -610,6 +610,10 @@ class OneLogin_Saml2_Response
             }
         } else {
             if ($this->_settings->isStrict() && empty($nameId->nodeValue)) {
+                $security = $this->_settings->getSecurityData();
+                if (!$security['wantNameId']) {
+                    return $nameIdData;
+                }
                 throw new OneLogin_Saml2_ValidationError(
                     "An empty NameID value found",
                     OneLogin_Saml2_ValidationError::EMPTY_NAMEID


### PR DESCRIPTION
We are facing issues when our IP sends empty nameId. There is no reason to throw Exception when I set setting wantNameId as false. Disabling _strict is not good way, I thing. Thank you!