### PR TITLE
Fixes #579 buildWithBaseURLPath return only last part of url 

### DIFF
--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -705,12 +705,12 @@ class OneLogin_Saml2_Utils
         $baseURLPath = self::getBaseURLPath();
         if (!empty($baseURLPath)) {
             $result = $baseURLPath;
-            if (!empty($info)) {
-                $path = explode('/', $info);
-                $extractedInfo = array_pop($path);
-                if (!empty($extractedInfo)) {
-                    $result .= $extractedInfo;
-                }
+            // Remove base path from the path info.
+            $extractedInfo = str_replace($baseURLPath, '', $info);
+            // Remove starting and ending slash.
+            $extractedInfo = trim($extractedInfo, '/');
+            if (!empty($extractedInfo)) {
+                $result .= $extractedInfo;
             }
         }
         return $result;


### PR DESCRIPTION
The `array_pop()` assumes the last part of the path is the only valid leading an `invalid_response` error:

> "The response was received at https://example.com/sub-directory/acs instead of https://example.com/sub-directory/saml/acs"