### PR TITLE
Fixes #579 buildWithBaseURLPath return only last part of url

### DIFF
--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -722,8 +722,10 @@ class Utils
         if (!empty($baseURLPath)) {
             $result = $baseURLPath;
             if (!empty($info)) {
-                $path = explode('/', $info);
-                $extractedInfo = array_pop($path);
+                // Remove base path from the path info.
+                $extractedInfo = str_replace($baseURLPath, '', $info);
+                // Remove starting and ending slash.
+                $extractedInfo = trim($extractedInfo, '/');
                 if (!empty($extractedInfo)) {
                     $result .= $extractedInfo;
                 }


### PR DESCRIPTION
The `array_pop()` assumes the last part of the path is the only valid leading an `invalid_response` error:

> "The response was received at https://example.com/sub-directory/acs instead of https://example.com/sub-directory/saml/acs"