### PR TITLE
Declare conditional return types

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -246,6 +246,7 @@ class OneLogin_Saml2_Auth
      * @param bool        $stay                         True if we want to stay (returns the url string) False to redirect
      *
      * @return string|null
+     * @phpstan-return ($stay is true ? string : never)
      *
      * @throws OneLogin_Saml2_Error
      */
@@ -498,6 +499,7 @@ class OneLogin_Saml2_Auth
      * @param string $nameIdValueReq Indicates to the IdP the subject that should be authenticated
      *
      * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     * @phpstan-return ($stay is true ? string : never)
      *
      * @throws OneLogin_Saml2_Error
      */
@@ -540,6 +542,7 @@ class OneLogin_Saml2_Auth
      * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
      *
      * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     * @phpstan-return ($stay is true ? string : never)
      *
      * @throws OneLogin_Saml2_Error
      */

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -300,6 +300,7 @@ class OneLogin_Saml2_Utils
      * @param bool         $stay       True if we want to stay (returns the url string) False to redirect
      *
      * @return string|null $url
+     * @phpstan-return ($stay is true ? string : never)
      *
      * @throws OneLogin_Saml2_Error
      */


### PR DESCRIPTION
with the added types, PHPStan, psalm and other static analysis tools can assist the user of the library better.
meaning even if the phpdoc is prefixed with `@phpstan` it will work for the other ones.

the tooling will realize when the call to the changed functions will never return or when a string is returned.
