### PR TITLE
Remove wrong PHPDoc

### DIFF
--- a/src/Saml2/Auth.php
+++ b/src/Saml2/Auth.php
@@ -220,7 +220,6 @@ class Auth
      * Process the SAML Response sent by the IdP.
      *
      * @param string|null $requestId The ID of the AuthNRequest sent by this SP to the IdP
-     * @phpstan-return ($stay is true ? string : never)
      *
      * @throws Error
      * @throws ValidationError


### PR DESCRIPTION
The `processResponse` method has no `$stay` variable and the `@phpstan-return` PHPDoc was giving me a hard time in PHPStan.