### PR TITLE
Do not confuse Settings::getIdPSLOResponseUrl() with bad example

### DIFF
--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -543,26 +543,19 @@ class OneLogin_Saml2_Settings
                 $errors[] = 'idp_entityId_not_found';
             }
 
-            if (!isset($idp['singleSignOnService'])
-                || !isset($idp['singleSignOnService']['url'])
-                || empty($idp['singleSignOnService']['url'])
-            ) {
+            if (!isset($idp['singleSignOnService']['url'])) {
                 $errors[] = 'idp_sso_not_found';
             } else if (!filter_var($idp['singleSignOnService']['url'], FILTER_VALIDATE_URL)) {
                 $errors[] = 'idp_sso_url_invalid';
             }
 
-            if (isset($idp['singleLogoutService'])
-                && isset($idp['singleLogoutService']['url'])
-                && !empty($idp['singleLogoutService']['url'])
+            if (isset($idp['singleLogoutService']['url'])
                 && !filter_var($idp['singleLogoutService']['url'], FILTER_VALIDATE_URL)
             ) {
                 $errors[] = 'idp_slo_url_invalid';
             }
 
-            if (isset($idp['singleLogoutService'])
-                && isset($idp['singleLogoutService']['responseUrl'])
-                && !empty($idp['singleLogoutService']['responseUrl'])
+            if (isset($idp['singleLogoutService']['responseUrl'])
                 && !filter_var($idp['singleLogoutService']['responseUrl'], FILTER_VALIDATE_URL)
             ) {
                 $errors[] = 'idp_slo_response_url_invalid';

--- a/settings_example.php
+++ b/settings_example.php
@@ -95,7 +95,7 @@ $settings = array (
             'url' => '',
             // URL location of the IdP where the SP will send the SLO Response (ResponseLocation)
             // if not set, url for the SLO Request will be used
-            'responseUrl' => '',
+            // 'responseUrl' => '',
             // SAML protocol binding to be used when returning the <Response>
             // message.  SAML Toolkit supports for this endpoint the
             // HTTP-Redirect binding only


### PR DESCRIPTION
When IdP configuration has the `responseUrl` set to an empty string, as it is currently in the example config file, during the single log out flow when `LogoutRequest` is received, that could lead to the attempt to respond to the IdP using a `RelayState` value, rather than `singleLogoutService.url` value, because unlike `Settings::checkIdPSettings()`, `Settings::getIdPSLOResponseUrl()` only checks if `responseUrl` `isset()` like is it demonstrated here https://3v4l.org/VhEdl .

In my opinion, `Settings::checkIdPSettings()` should be improved to error on an empty string in the  `responseUrl` value which is implemented in a separate commit.