### PR TITLE
Fix metadata typo when using ignoreValidUntil

### DIFF
--- a/lib/Saml2/Metadata.php
+++ b/lib/Saml2/Metadata.php
@@ -155,7 +155,7 @@ METADATA_TEMPLATE;
 
         if ($ignoreValidUntil) {
             $timeStr = <<<TIME_TEMPLATE
-cacheDuration="PT{$cacheDuration}S";
+cacheDuration="PT{$cacheDuration}S"
 TIME_TEMPLATE;
         } else {
             $timeStr = <<<TIME_TEMPLATE


### PR DESCRIPTION
Found this typo in https://github.com/SAML-Toolkits/php-saml/commit/f43b38875b09371c34c8a21bf358335aa97e83dc when testing on my installation – the extra semicolon results in invalid metadata xml.

This is my first PR on this kind of project, apologies if there's etiquette here I'm not aware of. Thanks for all your prior work helping to preserve this very useful library!