### PR TITLE
ignoreValidUntil improvements

### DIFF
--- a/src/Saml2/Metadata.php
+++ b/src/Saml2/Metadata.php
@@ -172,7 +172,7 @@ METADATA_TEMPLATE;
 
         if ($ignoreValidUntil) {
             $timeStr = <<<TIME_TEMPLATE
-cacheDuration="PT{$cacheDuration}S";
+cacheDuration="PT{$cacheDuration}S"
 TIME_TEMPLATE;
         } else {
             $timeStr = <<<TIME_TEMPLATE

--- a/src/Saml2/Settings.php
+++ b/src/Saml2/Settings.php
@@ -879,14 +879,15 @@ class Settings
      * $advancedSettings['security']['wantAssertionsEncrypted'] are enabled.
      * @param int|null      $validUntil    Metadata's valid time
      * @param int|null      $cacheDuration Duration of the cache in seconds
+     * @param bool          $ignoreValidUntil exclude the validUntil tag from metadata
      *
      * @return string  SP metadata (xml)
      * @throws Exception
      * @throws Error
      */
-    public function getSPMetadata($alwaysPublishEncryptionCert = false, $validUntil = null, $cacheDuration = null)
+    public function getSPMetadata($alwaysPublishEncryptionCert = false, $validUntil = null, $cacheDuration = null, $ignoreValidUntil = false)
     {
-        $metadata = Metadata::builder($this->_sp, $this->_security['authnRequestsSigned'], $this->_security['wantAssertionsSigned'], $validUntil, $cacheDuration, $this->getContacts(), $this->getOrganization());
+        $metadata = Metadata::builder($this->_sp, $this->_security['authnRequestsSigned'], $this->_security['wantAssertionsSigned'], $validUntil, $cacheDuration, $this->getContacts(), $this->getOrganization(), [], $ignoreValidUntil);
 
         $certNew = $this->getSPcertNew();
         if (!empty($certNew)) {


### PR DESCRIPTION
- Fix typo in ignoreValidUntil that breaks metadata, See #603
- Add parameter to exclude validUntil on Settings getSPMetadata, See #568