### PR TITLE
ignoreValidUntil improvements (master)

### DIFF
--- a/lib/Saml2/Metadata.php
+++ b/lib/Saml2/Metadata.php
@@ -155,7 +155,7 @@ METADATA_TEMPLATE;
 
         if ($ignoreValidUntil) {
             $timeStr = <<<TIME_TEMPLATE
-cacheDuration="PT{$cacheDuration}S";
+cacheDuration="PT{$cacheDuration}S"
 TIME_TEMPLATE;
         } else {
             $timeStr = <<<TIME_TEMPLATE

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -888,6 +888,7 @@ class OneLogin_Saml2_Settings
      *   or $advancedSettings['security']['wantAssertionsEncrypted'] are enabled.
      * @param DateTime|null $validUntil    Metadata's valid time
      * @param int|null      $cacheDuration Duration of the cache in seconds
+     * @param bool          $ignoreValidUntil exclude the validUntil tag from metadata
      *
      * @return string  SP metadata (xml)
      *
@@ -896,7 +897,7 @@ class OneLogin_Saml2_Settings
      */
     public function getSPMetadata($alwaysPublishEncryptionCert = false, $validUntil = null, $cacheDuration = null)
     {
-        $metadata = OneLogin_Saml2_Metadata::builder($this->_sp, $this->_security['authnRequestsSigned'], $this->_security['wantAssertionsSigned'], $validUntil, $cacheDuration, $this->getContacts(), $this->getOrganization());
+        $metadata = OneLogin_Saml2_Metadata::builder($this->_sp, $this->_security['authnRequestsSigned'], $this->_security['wantAssertionsSigned'], $validUntil, $cacheDuration, $this->getContacts(), $this->getOrganization(), [], $ignoreValidUntil);
 
         $certNew = $this->getSPcertNew();
         if (!empty($certNew)) {

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -895,9 +895,9 @@ class OneLogin_Saml2_Settings
      * @throws Exception
      * @throws OneLogin_Saml2_Error
      */
-    public function getSPMetadata($alwaysPublishEncryptionCert = false, $validUntil = null, $cacheDuration = null)
+    public function getSPMetadata($alwaysPublishEncryptionCert = false, $validUntil = null, $cacheDuration = null, $ignoreValidUntil = false)
     {
-        $metadata = OneLogin_Saml2_Metadata::builder($this->_sp, $this->_security['authnRequestsSigned'], $this->_security['wantAssertionsSigned'], $validUntil, $cacheDuration, $this->getContacts(), $this->getOrganization(), [], $ignoreValidUntil);
+        $metadata = OneLogin_Saml2_Metadata::builder($this->_sp, $this->_security['authnRequestsSigned'], $this->_security['wantAssertionsSigned'], $validUntil, $cacheDuration, $this->getContacts(), $this->getOrganization(), array(), $ignoreValidUntil);
 
         $certNew = $this->getSPcertNew();
         if (!empty($certNew)) {


### PR DESCRIPTION
- Fix typo in ignoreValidUntil that breaks metadata, See https://github.com/SAML-Toolkits/php-saml/issues/603
- Add parameter to exclude validUntil on Settings getSPMetadata, See https://github.com/SAML-Toolkits/php-saml/issues/568