### PR TITLE
Improve validate binary sign

### DIFF
--- a/src/Saml2/Error.php
+++ b/src/Saml2/Error.php
@@ -40,6 +40,7 @@ class Error extends Exception
     const SAML_SINGLE_LOGOUT_NOT_SUPPORTED = 12;
     const PRIVATE_KEY_NOT_FOUND = 13;
     const UNSUPPORTED_SETTINGS_OBJECT = 14;
+    const INVALID_PARAMETER = 15;
 
     /**
      * Constructor

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -743,6 +743,10 @@ class Utils
      */
     public static function extractOriginalQueryParam($name)
     {
+        if (!isset($_SERVER['QUERY_STRING']) || empty($_SERVER['QUERY_STRING'])) {
+            return '';
+        }
+
         $index = strpos($_SERVER['QUERY_STRING'], $name.'=');
         $substring = substr($_SERVER['QUERY_STRING'], $index + strlen($name) + 1);
         $end = strpos($substring, '&');
@@ -1541,13 +1545,43 @@ class Utils
             $signAlg = $getData['SigAlg'];
         }
 
+
         if ($retrieveParametersFromServer) {
+            if (!isset($_SERVER['QUERY_STRING']) || empty($_SERVER['QUERY_STRING'])) {
+                throw new Error(
+                    "No query string provided",
+                    Error::INVALID_PARAMETER
+                );
+            }
+            $keys = ["SAMLRequest", "SAMLResponse", "RelayState", "SigAlg", "Signature"];
+            foreach ($keys as $key) {
+                if (substr_count($_SERVER['QUERY_STRING'], $key) > 1) {
+                    throw new Error(
+                        "Duplicate parameter in query string",
+                        Error::INVALID_PARAMETER
+                    );
+                }
+            }
+            if (substr_count($_SERVER['QUERY_STRING'], "SAMLRequest") > 0 && substr_count($_SERVER['QUERY_STRING'], "SAMLResponse") > 0) {
+                throw new Error(
+                    "Both SAMLRequest and SAMLResponse provided",
+                    Error::INVALID_PARAMETER
+                );
+            }
+
             $signedQuery = $messageType.'='.Utils::extractOriginalQueryParam($messageType);
             if (isset($getData['RelayState'])) {
                 $signedQuery .= '&RelayState='.Utils::extractOriginalQueryParam('RelayState');
             }
             $signedQuery .= '&SigAlg='.Utils::extractOriginalQueryParam('SigAlg');
         } else {
+            if (isset($getData['SAMLRequest']) && isset($getData['SAMLResponse'])) {
+                throw new Error(
+                    "Both SAMLRequest and SAMLResponse provided",
+                    Error::INVALID_PARAMETER
+                );
+            }
+
             $signedQuery = $messageType.'='.urlencode($getData[$messageType]);
             if (isset($getData['RelayState'])) {
                 $signedQuery .= '&RelayState='.urlencode($getData['RelayState']);

--- a/tests/src/OneLogin/Saml2/UtilsTest.php
+++ b/tests/src/OneLogin/Saml2/UtilsTest.php
@@ -1310,4 +1310,432 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $this->assertStringContainsString('Reference validation failed', $e->getMessage());
         }
     }
+
+    /**
+     * Tests the validateBinarySign method of the Utils
+     *
+     * @covers OneLogin\Saml2\Utils::validateSign
+     */
+    public function testValidateBinarySignIsValid()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new Settings($settingsInfo);
+        $idpData = $settings->getIdPData();
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData = array(
+            'SAMLRequest' => 'fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=',
+            'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrcTsSFlYYbcqr/g5Kdcgg='
+        );
+        $retrieveParametersFromServer = false;
+        $messageType = 'SAMLRequest';
+        $this->assertTrue(Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer));
+
+        $retrieveParametersFromServer = true;
+        $_SERVER['QUERY_STRING'] = 'SAMLRequest=' . urlencode('fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE='). '&RelayState='.urlencode('_1037fbc88ec82ce8e770b2bed1119747bb812a07e6') . '&SigAlg='.urlencode('http://www.w3.org/2000/09/xmldsig#rsa-sha1').'&Signature=' . urlencode('L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrc');
+        $this->assertTrue(Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer));
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData2 = array(
+            'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
+            'RelayState' => 'https://pitbulk.no-ip.org/newonelogin/demo1/index.php',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA='
+        );
+        $retrieveParametersFromServer = false;
+        $messageType = 'SAMLResponse';
+        $this->assertTrue(Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer));
+
+        $retrieveParametersFromServer = true;
+        $_SERVER['QUERY_STRING'] = 'SAMLResponse='.urlencode('fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A').'&RelayState='.urlencode('https://pitbulk.no-ip.org/newonelogin/demo1/index.php').'&SigAlg='.urlencode('http://www.w3.org/2000/09/xmldsig#rsa-sha1').'&Signature='.urlencode('vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA=');
+        $this->assertTrue(Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer));
+    }
+
+    /**
+     * Tests the validateBinarySign method of the Utils
+     *
+     * @covers OneLogin\Saml2\Utils::validateSign
+     */
+    public function testValidateBinarySignIsValidx509certMulti()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings6.php';
+
+        $settings = new Settings($settingsInfo);
+        $idpData = $settings->getIdPData();
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData = array(
+            'SAMLRequest' => 'fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=',
+            'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrcTsSFlYYbcqr/g5Kdcgg='
+        );
+        $retrieveParametersFromServer = false;
+        $messageType = 'SAMLRequest';
+        $this->assertTrue(Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer));
+
+        $retrieveParametersFromServer = true;
+        $_SERVER['QUERY_STRING'] = 'SAMLRequest=' . urlencode('fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE='). '&RelayState='.urlencode('_1037fbc88ec82ce8e770b2bed1119747bb812a07e6') . '&SigAlg='.urlencode('http://www.w3.org/2000/09/xmldsig#rsa-sha1').'&Signature=' . urlencode('L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrc');
+        $this->assertTrue(Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer));
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData2 = array(
+            'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
+            'RelayState' => 'https://pitbulk.no-ip.org/newonelogin/demo1/index.php',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA='
+        );
+        $retrieveParametersFromServer = false;
+        $messageType = 'SAMLResponse';
+        $this->assertTrue(Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer));
+
+        $retrieveParametersFromServer = true;
+        $_SERVER['QUERY_STRING'] = 'SAMLResponse='.urlencode('fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A').'&RelayState='.urlencode('https://pitbulk.no-ip.org/newonelogin/demo1/index.php').'&SigAlg='.urlencode('http://www.w3.org/2000/09/xmldsig#rsa-sha1').'&Signature='.urlencode('vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA=');
+        $this->assertTrue(Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer));
+    }
+
+    /**
+     * Tests the validateBinarySign method of the Utils
+     * Case where the signature is wrong 
+     * 
+     * @covers OneLogin\Saml2\Utils::validateSign
+     */
+    public function testValidateBinarySignSignatureWrong()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new Settings($settingsInfo);
+        $idpData = $settings->getIdPData();
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData = array(
+            'SAMLRequest' => 'fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=',
+            'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'WRONGL2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrcTsSFlYYbcqr/g5Kdcgg='
+        );
+        $retrieveParametersFromServer = false;
+        $messageType = 'SAMLRequest';
+        $this->assertFalse(Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer));
+
+        $getData2 = array(
+            'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
+            'RelayState' => 'https://pitbulk.no-ip.org/newonelogin/demo1/index.php',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'WRONGvfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA='
+        );
+        $retrieveParametersFromServer = false;
+        $messageType = 'SAMLResponse';
+        $this->assertFalse(Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer));
+    }
+
+    /**
+     * Tests the validateBinarySign method of the Utils
+     * Case where the cert is wrong 
+     * 
+     * @covers OneLogin\Saml2\Utils::validateSign
+     */
+    public function testValidateBinarySignCertWrong()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settingsInfo['idp']['x509cert'] = 'MIICZDCCAc2gAwIBAgIBADANBgkqhkiG9w0BAQ0FADBPMQswCQYDVQQGEwJ1czEUMBIGA1UECAwLZXhhbXBsZS5jb20xFDASBgNVBAoMC2V4YW1wbGUuY29tMRQwEgYDVQQDDAtleGFtcGxlLmNvbTAeFw0yNTA1MjQyMjUyNTlaFw0zNTA1MjIyMjUyNTlaME8xCzAJBgNVBAYTAnVzMRQwEgYDVQQIDAtleGFtcGxlLmNvbTEUMBIGA1UECgwLZXhhbXBsZS5jb20xFDASBgNVBAMMC2V4YW1wbGUuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQD4pXDtSHXYCBA7j5Rc5v+Eh1QigIN2BPXcLtzvaQL5ajifXoQsXuSkcO3Rg7kcTVFcSjhtvM7/NUDq8yEq5g6cYCbdJHXCPH2xkotS57YWkY8zYohOuSa8LNLNeBVTcngQqLbprjgUAXjyXq8rlXu80lNgMw8eo7MbQCQpgC4VqwIDAQABo1AwTjAdBgNVHQ4EFgQUmPov0WxzvYUtCluz0AEFFWIx/NYwHwYDVR0jBBgwFoAUmPov0WxzvYUtCluz0AEFFWIx/NYwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOBgQCHTsdA7LbSeDRiqqOHw+50ncIFCC2s4m6qBaxNrwSSyhoZKWhyUNxfnKIB4s/jaQxITn6U8hvuEv6e3Ews+07j4yIISF2SWefStAf8P/7Rt+qHQiV2zcE/RzxW4Trvav1dIfjqF26hOPQqGVnAKGP8wcjsEhwxUVOLP6EUTIoH3A==';
+        $settings = new Settings($settingsInfo);
+
+        $idpData = $settings->getIdPData();
+        $retrieveParametersFromServer = false;
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData = array(
+            'SAMLRequest' => 'fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=',
+            'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrcTsSFlYYbcqr/g5Kdcgg='
+        );
+        $messageType = 'SAMLRequest';
+        $this->assertFalse(Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer));
+
+        $getData2 = array(
+            'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
+            'RelayState' => 'https://pitbulk.no-ip.org/newonelogin/demo1/index.php',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA='
+        );
+        $messageType = 'SAMLResponse';
+        $this->assertFalse(Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer));
+    }
+
+    /**
+     * Tests the validateBinarySign method of the Utils
+     * Case removed element, ex RelayState
+     * 
+     * @covers OneLogin\Saml2\Utils::validateSign
+     */
+    public function testValidateBinarySignRemovedParam()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new Settings($settingsInfo);
+
+        $idpData = $settings->getIdPData();
+        $retrieveParametersFromServer = false;
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData = array(
+            'SAMLRequest' => 'fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=',
+            'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrcTsSFlYYbcqr/g5Kdcgg='
+        );
+        unset($getData['RelayState']);
+        $messageType = 'SAMLRequest';
+        $this->assertFalse(Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer));
+
+        $getData2 = array(
+            'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
+            'RelayState' => 'https://pitbulk.no-ip.org/newonelogin/demo1/index.php',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA='
+        );
+        unset($getData2['RelayState']);
+        $messageType = 'SAMLResponse';
+        $this->assertFalse(Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer));
+    }
+
+    /**
+     * Tests the validateBinarySign method of the Utils
+     * Case No Query String
+     * 
+     * @covers OneLogin\Saml2\Utils::validateSign
+     */
+    public function testValidateBinarySignNoQueryString()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new Settings($settingsInfo);
+
+        $idpData = $settings->getIdPData();
+        $retrieveParametersFromServer = true;
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData = array(
+            'SAMLRequest' => 'fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=',
+            'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrcTsSFlYYbcqr/g5Kdcgg='
+        );
+        unset($getData['RelayState']);
+        $messageType = 'SAMLRequest';
+        try {
+            Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "No query string provided";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+
+        $getData2 = array(
+            'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
+            'RelayState' => 'https://pitbulk.no-ip.org/newonelogin/demo1/index.php',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA='
+        );
+        unset($getData2['RelayState']);
+        $messageType = 'SAMLResponse';
+        try {
+            Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "No query string provided";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+    }
+
+    /**
+     * Tests the validateBinarySign method of the Utils
+     * Case No Cert
+     * 
+     * @covers OneLogin\Saml2\Utils::validateSign
+     */
+    public function testValidateBinarySignNoCert()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new Settings($settingsInfo);
+
+        $idpData = $settings->getIdPData();
+        unset($idpData['x509cert']);
+
+        $retrieveParametersFromServer = false;
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData = array(
+            'SAMLRequest' => 'fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=',
+            'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrcTsSFlYYbcqr/g5Kdcgg='
+        );
+        $messageType = 'SAMLRequest';
+        try {
+            Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "In order to validate the sign on the Logout Request, the x509cert of the IdP is required";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+
+        $getData2 = array(
+            'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
+            'RelayState' => 'https://pitbulk.no-ip.org/newonelogin/demo1/index.php',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA='
+        );
+        $messageType = 'SAMLResponse';
+        try {
+            Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "In order to validate the sign on the Logout Response, the x509cert of the IdP is required";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+    }
+
+
+    /**
+     * Tests the validateBinarySign method of the Utils
+     * Case Invalid Parameters: Ex. SAMLRequest and SAMLResponse present at the same time
+     * 
+     * @covers OneLogin\Saml2\Utils::validateSign
+     */
+    public function testValidateBinarySignReqAndRes()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new Settings($settingsInfo);
+
+        $idpData = $settings->getIdPData();
+        $retrieveParametersFromServer = false;
+
+        unset($_SERVER['QUERY_STRING']);
+        $getData = array(
+            'SAMLRequest' => 'fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=',
+            'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
+            'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrcTsSFlYYbcqr/g5Kdcgg='
+        );
+
+        $messageType = 'SAMLRequest';
+        try {
+            Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "Both SAMLRequest and SAMLResponse provided";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+
+        $retrieveParametersFromServer = true;
+        $_SERVER['QUERY_STRING'] = 'SAMLRequest=' . urlencode('fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE='). '&RelayState='.urlencode('_1037fbc88ec82ce8e770b2bed1119747bb812a07e6') . '%SAMLResponse=' . urlencode('fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A') . '&SigAlg='.urlencode('http://www.w3.org/2000/09/xmldsig#rsa-sha1').'&Signature=' . urlencode('L2YrP7Ngms1ew8va4drALt9bjK4ZInIS8V6W3HUSlvW/Hw2VD93vy1jPdDBsrRt8cLIuAkkHatemiq1bbgWyrGqlbX5VA/klRYJvHVowfUh2vuf8s17bdFWUOlsTWXxKaA2lJl93MnzJQsZrfVeCqJrc');
+        try {
+            Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "Both SAMLRequest and SAMLResponse provided";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+        
+        $getData2 = array(
+            'SAMLRequest' => 'fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=',
+            'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
+            'RelayState' => 'https://pitbulk.no-ip.org/newonelogin/demo1/index.php',
+            'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+            'Signature' => 'vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA='
+        );
+
+        $messageType = 'SAMLResponse';
+        $retrieveParametersFromServer = false;
+        try {
+            Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "Both SAMLRequest and SAMLResponse provided";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+
+        $retrieveParametersFromServer = true;
+        $_SERVER['QUERY_STRING'] = 'SAMLRequest='. urlencode('fZJNa+MwEIb/ivHdiTyyZEskhkJYCPQDtmUPvQRZHm8NtqRKMuTnr2J3IbuHXsQwM887My86BDVPTj7a33aJP/FzwRCz6zyZINfKMV+8kVaFMUijZgwyavn68PQoYUek8zZabaf8DvmeUCGgj6M1eXY+HfOLILwHVQ+MK1ozrBG7itQcKzpQ3pQCdDU0DdQIefYLfUjkMU9CCQ9hwbMJUZmYUqSsCkILIG8ll8Alg/c8O6VrRqPiSn3E6OR+H+IyDDtt5z2a3tnRxHAXhSns3IfLs2cbX8yLfxgi+iQvBC2IKKB8g1JWm3x7uN0r10V8+yU/9m6HVzW7Cdchh/1900Y8J1vOp+yH9bOK3/t1y4x9MaytMnplwogm5u1l6KDrgUHFGeVEU92xUlCkrOZMNITr9LIUdvprhW3qtoKTrxhuZp5Nj9f2gn0D0IPQyfnkPlOEQpO0uko1DDSBqqtEl+aITew//m/yn2/U/gE=') . '&SAMLResponse='.urlencode('fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A').'&RelayState='.urlencode('https://pitbulk.no-ip.org/newonelogin/demo1/index.php').'&SigAlg='.urlencode('http://www.w3.org/2000/09/xmldsig#rsa-sha1').'&Signature='.urlencode('vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA=');
+        try {
+            Utils::validateBinarySign($messageType, $getData2, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "Both SAMLRequest and SAMLResponse provided";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+    }
+
+    /**
+     * Tests the validateBinarySign method of the Utils
+     * Case Invalid Parameters: Ex. Duplicated Parameters
+     * 
+     * @covers OneLogin\Saml2\Utils::validateSign
+     */
+    public function testValidateBinarySignDuplicatedParameters()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings6.php';
+
+        $settings = new Settings($settingsInfo);
+        $idpData = $settings->getIdPData();
+
+        $getData = array();
+        $retrieveParametersFromServer = true;
+        $messageType = 'SAMLRequest';
+
+        $_SERVER['QUERY_STRING'] = 'SAMLRequest=xxx&SAMLRequest=yyy';
+        try {
+            Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "Duplicate parameter in query string";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+
+        $_SERVER['QUERY_STRING'] = 'SAMLResponse=xxx&SAMLResponse=yyy';
+        try {
+            Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "Duplicate parameter in query string";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+
+        $_SERVER['QUERY_STRING'] = 'RelayState=xxx&RelayState=yyy';
+        try {
+            Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "Duplicate parameter in query string";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+
+        $_SERVER['QUERY_STRING'] = 'SigAlg=xxx&SigAlg=yyy';
+        try {
+            Utils::validateBinarySign($messageType, $getData, $idpData, $retrieveParametersFromServer);
+            $this->fail('Error was not raised');
+        } catch (Exception $e) {
+            $expectedMessage = "Duplicate parameter in query string";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
While php-saml is not vulnerable to the user impersonation described on CVE-2025-27773, parameter checks were added to the validateBinarySign method to avoid any potential signature confusion attack in the HTTPRedirect binding

This PR:
- Add Parameter checking on validateBinarySign, inspired on CVE-2025-27773 fix
- Add test coverage for validateBinarySign