### PR TITLE
[Master] Update Github Actions and PHP dependencies

### DIFF
--- a/.github/workflows/php-package.yml
+++ b/.github/workflows/php-package.yml
@@ -50,6 +50,13 @@ jobs:
           ini-values: post_max_size=256M, max_execution_time=180
           coverage: xdebug2
 
+      # setup-php installs Composer 2.10.x which requires PHP 7.2.5+.
+      # For PHP 5.3–7.1 we must replace it with the 2.2 LTS phar.
+      - name: Install Composer 2.2 LTS
+        run: |
+          sudo curl -sS https://getcomposer.org/download/2.2.29/composer.phar -o "$(which composer)"
+          composer --version
+
       - name: Validate composer.json and composer.lock
         run: composer validate
 

--- a/.github/workflows/php-package.yml
+++ b/.github/workflows/php-package.yml
@@ -42,7 +42,7 @@ jobs:
       # Pin to SHA. Right now using >= 2.37.1 which fixes CVE-2026-46420
       # Check https://github.com/shivammathur/setup-php/releases for latest.
       - name: Setup PHP ${{ matrix.php-versions }}, with composer and extensions
-        uses: shivammathur/setup-php@7163319 # v2 — replace with full 40-char SHA from latest release
+        uses: shivammathur/setup-php@716331904ea2625d93a4f4f8f8c050d235845675 # v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, mcrypt, xml

--- a/.github/workflows/php-package.yml
+++ b/.github/workflows/php-package.yml
@@ -46,9 +46,10 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, mcrypt, xml
-          tools: composer:2.8.6@sha256:59b2c50e10cafa0d8efc19ede9a326d782f096c674a26baf98cf042ce23de890
+          # Composer 2.2 LTS supports PHP 5.3+
+          tools: composer:v2.2
           ini-values: post_max_size=256M, max_execution_time=180
-          coverage: xdebug
+          coverage: xdebug2
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/.github/workflows/php-package.yml
+++ b/.github/workflows/php-package.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, mcrypt, xml
-          tools: composer:v2
+          tools: composer:2.8.6@sha256:59b2c50e10cafa0d8efc19ede9a326d782f096c674a26baf98cf042ce23de890
           ini-values: post_max_size=256M, max_execution_time=180
           coverage: xdebug
 
@@ -55,7 +55,6 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer self-update
           composer install --prefer-source --no-interaction
 
       - name: Syntax check PHP

--- a/.github/workflows/php-package.yml
+++ b/.github/workflows/php-package.yml
@@ -50,6 +50,13 @@ jobs:
           ini-values: post_max_size=256M, max_execution_time=180
           coverage: xdebug2
 
+      # setup-php installs Composer 2.10.x which requires PHP 7.2.5+.
+      # For PHP 5.3–7.1 we must replace it with the 2.2 LTS phar.
+      - name: Install Composer 2.2 LTS
+        run: |
+          curl -sS https://getcomposer.org/download/2.2.29/composer.phar -o "$(which composer)"
+          composer --version
+
       - name: Validate composer.json and composer.lock
         run: composer validate
 

--- a/.github/workflows/php-package.yml
+++ b/.github/workflows/php-package.yml
@@ -8,31 +8,47 @@ on:
     branches: [ master, 3.*, 4.* ]
   pull_request:
     branches: [ master, 3.*, 4.* ]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
 
 jobs:
   test:
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        operating-system: ['ubuntu-latest']
-        php-versions: [5.3, 5.4, 5.5, 5.6, 7.0, 7.1]
+        operating-system: ['ubuntu-22.04'] # ubuntu-22.04 is the last runner with reliable PHP 5.x toolchain support.
+        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1']
     steps:
-      - name: Setup PHP, with composer and extensions
-        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+      # Checkout FIRST so the workspace is ready for all later steps.
+      # Pin to a full commit SHA for supply-chain safety.
+      # To find the latest SHA for a tag, run:
+      #   git ls-remote --tags https://github.com/actions/checkout.git | grep v4
+      #   or check https://github.com/actions/checkout/releases
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # Set git line-ending config
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      # Setup PHP
+      # Pin to SHA. Right now using >= 2.37.1 which fixes CVE-2026-46420
+      # Check https://github.com/shivammathur/setup-php/releases for latest.
+      - name: Setup PHP ${{ matrix.php-versions }}, with composer and extensions
+        uses: shivammathur/setup-php@7163319 # v2 — replace with full 40-char SHA from latest release
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, mcrypt, xml
           tools: composer:v2
           ini-values: post_max_size=256M, max_execution_time=180
           coverage: xdebug
-
-      - name: Set git to use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
-
-      - uses: actions/checkout@v4
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/.github/workflows/php-package.yml
+++ b/.github/workflows/php-package.yml
@@ -32,7 +32,7 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/.github/workflows/php-package.yml
+++ b/.github/workflows/php-package.yml
@@ -13,7 +13,6 @@ on:
 permissions:
   contents: read
 
-
 jobs:
   test:
     runs-on: ${{ matrix.operating-system }}
@@ -47,7 +46,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, mcrypt, xml
           # Composer 2.2 LTS supports PHP 5.3+
-          tools: composer:v2.2
+          tools: composer:2.2.29@f38623ebdeeab5905b24b048fd32804150e598436cc43db9fc12362894c1279d
           ini-values: post_max_size=256M, max_execution_time=180
           coverage: xdebug2
 

--- a/.github/workflows/php-package.yml
+++ b/.github/workflows/php-package.yml
@@ -46,16 +46,9 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, intl, mcrypt, xml
           # Composer 2.2 LTS supports PHP 5.3+
-          tools: composer:2.2.29@f38623ebdeeab5905b24b048fd32804150e598436cc43db9fc12362894c1279d
+          tools: composer:v2
           ini-values: post_max_size=256M, max_execution_time=180
           coverage: xdebug2
-
-      # setup-php installs Composer 2.10.x which requires PHP 7.2.5+.
-      # For PHP 5.3–7.1 we must replace it with the 2.2 LTS phar.
-      - name: Install Composer 2.2 LTS
-        run: |
-          curl -sS https://getcomposer.org/download/2.2.29/composer.phar -o "$(which composer)"
-          composer --version
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "satooshi/php-coveralls": "1.0.1",
-        "sebastian/phpcpd": "*",
-        "phploc/phploc": "*",
-        "pdepend/pdepend" : "1.1.0",
+        "php-coveralls/php-coveralls": "^1.0.2",
+        "sebastian/phpcpd": "^2.0 || ^3.0",
+        "phploc/phploc": "^2.1 || ^3.0 || ^4.0",
+        "pdepend/pdepend" : "^2.5.0",
         "squizlabs/php_codesniffer": "2.9.0"
     }
 }


### PR DESCRIPTION
- Update Checkout to 4.x
- Security improvements:

  -  Explicit minimal permissions (least privilege)
  -  Actions pinned to commit SHAs (supply-chain protection)
  - Runner OS pinned (reproducibility)
  - PHP versions quoted as strings (YAML float-safe)
  -  Job timeout set (cost/runaway protection)
  - Step ordering: checkout before setup-php
  - Removed non-deterministic composer self-update
  
  Fix PHP dependencies:
 ```
"php-coveralls/php-coveralls": "^1.0.2",
"sebastian/phpcpd": "^2.0 || ^3.0",
"phploc/phploc": "^2.1 || ^3.0 || ^4.0",
"pdepend/pdepend" : "^2.5.0",
 ```
  